### PR TITLE
Update 'fixer-v3' to fix a few weird edge cases

### DIFF
--- a/fixup-v3
+++ b/fixup-v3
@@ -7,10 +7,11 @@
 # 
 # implementation:
 # perl: remove null characters
-# grep: remove empty lines
+# sed: remove empty lines
+# perl: delete control characters between final } and newline
 # sed: replace all newline characters with comma
 # echo: add '[' to the start of file
 # sed: remove all characters before '{' at the start of each line starting from the second line
 # sed: remove the comma at the end of the file and replace it with ']'
 
-cat $1 | perl -p -e 's/\0\0../\n/g' | grep . | sed 's/$/,/g' | (/bin/echo -n \[ && cat) | sed '2,$ s/^.{/{/' | sed '$s/.$/]/' | python3 -m json.tool > $2
+cat $1 | perl -p -e 's/\0\0../\n/g' | sed '/^$/d' | perl -p -e 's/}(?:.(?!}))+$/}/g' | sed 's/$/,/g' | (/bin/echo -n \[ && cat) | sed '2,$ s/^.{/{/' | sed '$s/.$/]/' | python3 -m json.tool > $2


### PR DESCRIPTION
The old implementation (using grep .) had a weird edge case that caused half of my notes to be removed from the output JSON file. This was likely due to Unicode issues, as the note right after the cutoff had a metric ton of emojis and other unicode oddities.

The new version removes blank lines using sed, and also strips weird control characters from the end of each line as well using perl's negative-lookahead syntax. (this was likely a consequence of swapping grep out for sed)

With this change in place, the script should be more reliable, and should properly convert notes from the decrypted data into valid JSON without deleting half of them along the way.